### PR TITLE
Fixed Python init gain value for Windows system

### DIFF
--- a/Python/Open Camera, Grab Image to OpenCV/tis-OpenCV.py
+++ b/Python/Open Camera, Grab Image to OpenCV/tis-OpenCV.py
@@ -12,7 +12,9 @@ import ctypes as C
 import tisgrabber as IC
 import cv2
 import numpy as np
+import platform
 
+OS = platform.system()
 
 lWidth=C.c_long()
 lHeight= C.c_long()
@@ -76,7 +78,10 @@ if Camera.IsDevValid() == 1:
     print("Gain auto : ", Gainauto[0])
     
     Camera.SetPropertySwitch("Gain","Auto",0)
-    Camera.SetPropertyValue("Gain","Value",10)
+    if OS == "Windows":
+        Camera.SetPropertyValue("Gain","Value",64)
+    else:
+        Camera.SetPropertyValue("Gain","Value",10)
 
     WhiteBalanceAuto=[0]
     # Same goes with white balance. We make a complete red image:


### PR DESCRIPTION
Hi, first of all, thanks for sharing the nice sample code!
I ran into a Gain error when I ran this code on Windows. So I made some changes to the source code, looking at issues #25 and #3.
The minimum value for Gain on the Windows side is 64, so I entered the value directly.
If you like this fix, I'd be happy to merge it!