### PR TITLE
Fix: Calling TIS_CAM class from another directory

### DIFF
--- a/Python/Open Camera, Grab Image to OpenCV/tisgrabber.py
+++ b/Python/Open Camera, Grab Image to OpenCV/tisgrabber.py
@@ -11,6 +11,11 @@ import os
 import sys
 import numpy as np
 
+# get the current directory absolute path
+abs_path_to_directory = os.path.abspath(os.path.dirname(__file__))
+# add the directory to the os PATH, so that we can call the DLLs from any working directory.
+os.environ['PATH'] = abs_path_to_directory + os.pathsep + os.environ['PATH']
+
 class SinkFormats(Enum):
    Y800 = 0
    RGB24 = 1 


### PR DESCRIPTION
calling TIS_CAM class from different working directory results in dll load error. By adding the absolute path of tisgrabber.py directory will fix the DLL load error and python ctype will be able to find the DLL files.